### PR TITLE
Add fuels to fluid heat generator

### DIFF
--- a/src/main/java/orangelynx/ic2_extra_fuels/Ic2ExtraFuels.java
+++ b/src/main/java/orangelynx/ic2_extra_fuels/Ic2ExtraFuels.java
@@ -64,7 +64,7 @@ public class Ic2ExtraFuels {
                 additionalFuels.add(new Fuel(nextLine[0],
                                              Integer.parseInt(nextLine[1]),
                                              Double.parseDouble(nextLine[2]),
-                                             heatPerTick));
+                                             Double.parseDouble(nextLine[3])));
             }
 
             additionalFuelsConfigFileReader.close();

--- a/src/main/java/orangelynx/ic2_extra_fuels/Ic2ExtraFuels.java
+++ b/src/main/java/orangelynx/ic2_extra_fuels/Ic2ExtraFuels.java
@@ -61,7 +61,6 @@ public class Ic2ExtraFuels {
 
             String[] nextLine;
             while ((nextLine = additionalFuelsConfigFileReader.readNext()) != null) {
-                int heatPerTick = nextLine.length > 3 ? Integer.parseInt(nextLine[3]) : 0;
                 additionalFuels.add(new Fuel(nextLine[0],
                                              Integer.parseInt(nextLine[1]),
                                              Double.parseDouble(nextLine[2]),

--- a/src/main/java/orangelynx/ic2_extra_fuels/Ic2ExtraFuels.java
+++ b/src/main/java/orangelynx/ic2_extra_fuels/Ic2ExtraFuels.java
@@ -30,16 +30,18 @@ public class Ic2ExtraFuels {
     private List<Fuel> additionalFuels = new ArrayList<>();
 
     public final class Fuel {
-        public Fuel(String name, int amountConsumedPerTick, double powerGeneratedPerTick)
+        public Fuel(String name, int amountConsumedPerTick, double powerGeneratedPerTick, int heatGeneratedPerTick)
         {
             this.name = name;
             this.amountConsumedPerTick = amountConsumedPerTick;
             this.powerGeneratedPerTick = powerGeneratedPerTick;
+            this.heatGeneratedPerTick = heatGeneratedPerTick;
         }
 
         public String name;
         public int amountConsumedPerTick;
         public double powerGeneratedPerTick;
+        public int heatGeneratedPerTick;
     }
 
     @EventHandler
@@ -59,9 +61,11 @@ public class Ic2ExtraFuels {
 
             String[] nextLine;
             while ((nextLine = additionalFuelsConfigFileReader.readNext()) != null) {
+                int heatPerTick = nextLine.length > 3 ? Integer.parseInt(nextLine[3]) : 0;
                 additionalFuels.add(new Fuel(nextLine[0],
                                              Integer.parseInt(nextLine[1]),
-                                             Double.parseDouble(nextLine[2])));
+                                             Double.parseDouble(nextLine[2]),
+                                             heatPerTick));
             }
 
             additionalFuelsConfigFileReader.close();
@@ -80,6 +84,7 @@ public class Ic2ExtraFuels {
     {
         for (Fuel fuel: additionalFuels) {
             Recipes.semiFluidGenerator.addFluid(fuel.name, fuel.amountConsumedPerTick, fuel.powerGeneratedPerTick);
+            Recipes.fluidHeatGenerator.addFluid(fuel.name, fuel.amountConsumedPerTick, fuel.heatGeneratedPerTick);
         }
     }
 

--- a/src/main/resources/assets/config/additionalFuels.csv
+++ b/src/main/resources/assets/config/additionalFuels.csv
@@ -1,3 +1,3 @@
-"fuel_dense",4,2
-"fuel_light",2,16
-"fuel_gaseous",1,8
+"fuel_dense",4,2,8
+"fuel_light",2,16,64
+"fuel_gaseous",1,8,32


### PR DESCRIPTION
Addresses #2 by adding support for fluid heat generators.

Because the fluid heat generator produces heat instead of EU, this commit adds a third column to the config file indicating the amount of heat generated. For backwards compatibility, it assumes 0 if no column is present.